### PR TITLE
Automatic NPM Version Checking

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ export AKKERIS_API_HOST=apps.yourdomain.io
 export AKKERIS_AUTH_HOST=auth.yourdomain.io
 export API_AUTH = ".." # used to send "Authorization: ${API_AUTH}"
 export API_TOKEN = ".." # used to send "Authorization: Bearer ${API_TOKEN}"
+export AKA_UPDATE_INTERVAL # how often to check for updates (ms, default is 24 hours)
 ```
 
 Make sure you've added the entries to .netrc as well.

--- a/lib/terminal.js
+++ b/lib/terminal.js
@@ -337,6 +337,10 @@ function soft_error(strs) {
   console.log(markdown("  !!▸!!    " + strs));
 }
 
+function update_statement(current, latest) {
+  return markdown(`~~Update available! Run 'aka update' to update.~~ \n!!${current}!! -> ^^${latest}^^`)
+}
+
 module.exports = {
   question:question,
   hidden:hidden,
@@ -357,5 +361,6 @@ module.exports = {
   print:print,
   markdown:markdown,
   friendly_date:getDateDiff,
-  format_objects:format_objects
+  format_objects:format_objects,
+  update_statement:update_statement,
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "akkeris",
-  "version": "2.7.2",
+  "version": "2.7.3",
   "description": "Akkeris CLI",
   "main": "aka.js",
   "scripts": {


### PR DESCRIPTION
If the check for updates option is enabled (via aka auth:profile), the cli will asynchronously check for updates upon running a command if it's been at least AKA_UPDATE_INTERVAL (default 24hr) since the last check. The async command will save the result of the check in the ~/.akkeris/ directory as AKA_UPDATE_FILENAME (default .aka_version), and will be used when providing the usage statement to output the current version and the latest available version.