### PR TITLE
Improve CLI Help

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,15 @@
-
 ## Installing
-
-Add the following environment variables to your profile:
 
 ```bash
 npm -g install akkeris
 ak
-````
+```
+
+## Environment Variables
+
+```
+export AKKERIS_HELP_OLD=true   # Always show the old Akkeris help
+```
 
 ## Other env 
 
@@ -21,3 +24,7 @@ export AKA_UPDATE_INTERVAL # how often to check for updates (ms, default is 24 h
 ```
 
 Make sure you've added the entries to .netrc as well.
+
+## Documentation
+
+[https://docs.akkeris.io/](https://docs.akkeris.io/)

--- a/aka.js
+++ b/aka.js
@@ -227,7 +227,6 @@ function set_profile(appkit, args, cb) {
     appkit.terminal.question('Akkeris Auth Host (auth.example.com): ', (auth) => {
       appkit.terminal.question('Akkeris Apps Host (apps.example.com): ', (apps) => {
         appkit.terminal.question('Periodically check for updates? (y/n): ', (updates) => {
-          appkit.terminal.question('Always show the old Akkeris help? (y/n) ', (old_help) => {
             auth = auth.toLowerCase().trim()
             apps = apps.toLowerCase().trim()
             if (auth.startsWith('https://') || auth.startsWith('http://')) {
@@ -241,18 +240,11 @@ function set_profile(appkit, args, cb) {
             } else {
               updates = "0";
             }
-            if (old_help.toLowerCase().trim() === 'yes' || old_help.toLowerCase().trim() === 'y') {
-              old_help = "1";
-            } else {
-              old_help = "0";
-            }
-            fs.writeFileSync(path.join(get_home(), '.akkeris', 'config.json'), JSON.stringify({auth, apps, updates, old_help}, null, 2));
+            fs.writeFileSync(path.join(get_home(), '.akkeris', 'config.json'), JSON.stringify({auth, apps, updates}, null, 2));
             process.env.AKKERIS_API_HOST = apps
             process.env.AKKERIS_AUTH_HOST = auth
             process.env.AKKERIS_UPDATES = updates
-            process.env.AKKERIS_HELP_OLD = old_help
             console.log("Profile updated!")
-          });
         });
       });
     });
@@ -264,9 +256,6 @@ function load_config() {
   process.env.AKKERIS_AUTH_HOST = config.auth;
   process.env.AKKERIS_API_HOST = config.apps;
   process.env.AKKERIS_UPDATES = config.updates ? config.updates : 0;
-  if (!process.env.AKKERIS_HELP_OLD) {
-    process.env.AKKERIS_HELP_OLD = config.old_help ? config.old_help : 0;
-  }
 }
 
 function load_profile() {
@@ -484,7 +473,6 @@ function help(appkit, argv) {
   const invokedByHelp = argv._ && argv._.length > 0 && argv._[0] === 'help';
   const groupProvided = argv.group && argv.group.length > 0;
   const old_help = process.env.AKKERIS_HELP_OLD;
-
 
   if ((invokedByHelp && argv.a) || (
     old_help && (old_help === "1" || old_help.toLowerCase() === "true" || old_help.toLowerCase() === "t")

--- a/aka.js
+++ b/aka.js
@@ -12,7 +12,6 @@ const url = require('url');
 const zlib = require('zlib');
 const inquirer = require('inquirer');
 const fuzzy = require('fuzzy');
-const chalk = require('chalk');
 const stringWidth = require('string-width');
 inquirer.registerPrompt('autocomplete', require('inquirer-autocomplete-prompt'));
 
@@ -155,7 +154,7 @@ function squirrel_2() {
         Ol::clcoddddxkkOOOkxdolooooll:::ccclx    kc;''................',::odxk0      
           OxdoodkxxxkOOOkkxddolloollccc:cccccccd  x:'.................'.,:dokkx      
            kddddxxxxkOO0Oxxxdoloolcccc:ccccccccccdOc,..................,,;coxk       
-          oodxddkkxkO0 0Okxdoooollccc:;:ccc:ccccccc:,'..................,;;cdxO      
+          oodxddkkxkO000Okxdoooollccc:;:ccc:ccccccc:,'..................,;;cdxO      
          xlodxxxOOOOO00Okxdooodollllc::;::c::cccc:::,'.................''';;clO      
          olddkkkkkOO00Oxddolllolllcllc:::c::ccccc::;;'...................,,;:dO      
          llolkOkxkOOOkllolllolcllllllc::ccccccccc::;;,...................';cldkx     
@@ -189,6 +188,38 @@ function squirrel_2() {
                             |_|      
 
   `.split('\n').forEach((i, idx) => setTimeout(() => console.log(i), 25 * idx));
+}
+
+
+function squirrel_3() {
+  console.log(`
+              ,;:;;,
+              ;;;;;
+      .=',    ;:;;:,
+    /_', "=. ';:;:;
+    @=:__,  \,;:;:'
+      _(\.=  ;:;;'
+      \`"_(  _/="\`
+       \`"'\`\`
+
+       baby squirrel
+  `);
+}
+
+function squirrel_selector() {
+  switch(Math.floor(Math.random() * 3)) {
+    case 0:
+      squirrel();
+      break;
+    case 1:
+      squirrel_2();
+      break;
+    case 2:
+      squirrel_3();
+      break;
+    default:
+      squirrel();
+  }
 }
 
 function set_profile(appkit, args, cb) {
@@ -371,11 +402,11 @@ function print_ui(cliui, errorMessage) {
 }
 
 // Print help for a specific command group
-function print_group_help(argv, group) {
+function print_group_help(appkit, argv, group) {
   // Initialize UI
   let errorMessage = ''
   const ui = require('cliui')({width: process.stdout.columns})
-  ui.div(chalk.bold('\nAkkeris CLI Help\n'))
+  ui.div(appkit.terminal.bold('\nAkkeris CLI Help\n'))
 
   // Reset yargs so we can initialize it with only the plugin that we want
   const newYargs = require('yargs');
@@ -397,12 +428,12 @@ function print_group_help(argv, group) {
     if (foundCommand && foundCommand.length > 0) {
       newYargs.help(true).parse(`${foundCommand[0][0]} --help`)
     } else {
-      errorMessage = `${chalk.red.italic("Invalid command:")} ${givenCommand}`
+      errorMessage = `${appkit.terminal.italic(appkit.terminal.markdown("!!Invalid command:!!"))} ${givenCommand}`
     }
   }
 
   // Render the name of the group
-  ui.div(chalk.italic(capitalize(group)))
+  ui.div(appkit.terminal.italic(capitalize(group)))
 
   // Render all of the group commands
   const commands = newYargs.getUsageInstance().getCommands().sort((a, b) => a[0] < b[0] ? -1 : 1);
@@ -416,7 +447,7 @@ function print_group_help(argv, group) {
   ui.div();
 
   // Render helper text
-  ui.div(`\n${chalk.italic('Run')} ${chalk.yellow.italic(`${argv["$0"]} help <group> <command>`)} ${chalk.italic('to view help documentation for a specific command')}`);
+  ui.div(`\n${appkit.terminal.italic('Run')} ${appkit.terminal.italic(appkit.terminal.markdown(`~~${argv["$0"]} help <group> <command>~~`))} ${appkit.terminal.italic('to view help documentation for a specific command')}`);
   
   print_ui(ui, errorMessage);
 }
@@ -425,7 +456,7 @@ function print_group_help(argv, group) {
 function print_all_help(appkit, argv, errorMessage) {
   // Initialize UI
   const ui = require('cliui')({width: process.stdout.columns});
-  ui.div(chalk.bold('\nAkkeris CLI Help\n'));
+  ui.div(appkit.terminal.bold('\nAkkeris CLI Help\n'));
   
   // Render each command group
   Object.keys(appkit.plugins).sort().filter(group => !appkit.plugins[group].hidden).forEach((group) => {
@@ -433,7 +464,7 @@ function print_all_help(appkit, argv, errorMessage) {
   });
   
   // Render helper text
-  ui.div(`\n${chalk.italic('Run')} ${chalk.yellow.italic(`${argv["$0"]} help <group>`)} ${chalk.italic('to view help documentation for a specific command group')}`);
+  ui.div(`\n${appkit.terminal.italic('Run')} ${appkit.terminal.italic(appkit.terminal.markdown(`~~${argv["$0"]} help <group>~~`))} ${appkit.terminal.italic('to view help documentation for a specific command group')}`);
   
   print_ui(ui, errorMessage);
 }
@@ -466,13 +497,13 @@ function help(appkit, argv) {
   if (invokedByHelp && groupProvided) {
     const validGroup = Object.keys(appkit.plugins).filter(group => !appkit.plugins[group].hidden).find(group => group === argv.group[0])
     if (validGroup) {
-      print_group_help(argv, validGroup);      
+      print_group_help(appkit, argv, validGroup);      
       return;
     } else {
-      errorMessage = `${chalk.red.italic("Invalid command group:")} ${argv.group[0]}`;
+      errorMessage = `${appkit.terminal.italic(appkit.terminal.markdown("!!Invalid command group:!!"))} ${argv.group[0]}`;
     }
   } else if (!invokedByHelp && argv.group) {
-    errorMessage = `${chalk.red.italic("Unrecognized command:")} ${argv.group[0]}`;
+    errorMessage = `${appkit.terminal.italic(appkit.terminal.markdown("!!Unrecognized command:!!"))} ${argv.group[0]}`;
   }
 
   print_all_help(appkit, argv, errorMessage);
@@ -710,8 +741,7 @@ module.exports.init = function init() {
     .command('autocomplete', `Install bash/zsh shell autocompletion`, {}, install_auto_completions.bind(null, module.exports))
 
     // Secret Commands
-    .command('squirrel', false, {}, squirrel)
-    .command('squirrel_2.0', false, {}, squirrel_2)
+    .command('squirrel', false, {}, squirrel_selector)
 
     .recommendCommands()
     .middleware([help_options_middleware, help_flag_middleware.bind(null, module.exports)], true)
@@ -745,6 +775,7 @@ module.exports.init = function init() {
     module.exports.terminal.markdown('🚀  Did you know? When using repo:set if you don\'t specify a token it will use your organization\'s token.'),
     module.exports.terminal.markdown('🚀  Did you know? There\'s more out there! Run ##aka plugins## to explore optional akkeris features!'),
     module.exports.terminal.markdown('🚀  Did you know? You can use \'ak\' as a short cut for \'aka\'!'),
+    module.exports.terminal.markdown('🚀  You should try \'aka squirrel\'!'),
   ];
 }
 

--- a/aka.js
+++ b/aka.js
@@ -228,21 +228,26 @@ function set_profile(appkit, args, cb) {
   }
 }
 
+function load_config() {
+  let config = JSON.parse(fs.readFileSync(path.join(get_home(), '.akkeris', 'config.json')).toString('UTF8'))
+  process.env.AKKERIS_AUTH_HOST = config.auth;
+  process.env.AKKERIS_API_HOST = config.apps;
+  process.env.AKKERIS_UPDATES = config.updates ? config.updates : 0;
+  if (!process.env.AKKERIS_HELP_OLD) {
+    process.env.AKKERIS_HELP_OLD = config.old_help ? config.old_help : 0;
+  }
+}
+
 function load_profile() {
   if(!process.env.AKKERIS_API_HOST || !process.env.AKKERIS_AUTH_HOST) {
     try {
-      let config = JSON.parse(fs.readFileSync(path.join(get_home(), '.akkeris', 'config.json')).toString('UTF8'))
-      process.env.AKKERIS_AUTH_HOST = config.auth;
-      process.env.AKKERIS_API_HOST = config.apps;
-      process.env.AKKERIS_UPDATES = config.updates ? config.updates : 0;
-      if (!process.env.AKKERIS_HELP_OLD) {
-        process.env.AKKERIS_HELP_OLD = config.old_help ? config.old_help : 0;
-      }
+      load_config()
     } catch (e) {
       if(process.argv && (process.argv[1] === 'auth:profile' || process.argv[2] === 'auth:profile' || process.argv[3] === 'auth:profile')) {
         return;
       }
       welcome()
+      load_config()
     }
   }
   process.env.AKKERIS_AUTH_HOST = process.env.AKKERIS_AUTH_HOST.toLowerCase().trim()

--- a/lib/terminal.js
+++ b/lib/terminal.js
@@ -1,6 +1,8 @@
 const util = require('util');
 const assert = require('assert');
+var ui = require ('cliui');
 var cli_table = require('cli-table');
+
 // colors array: [dark, med, light]
 var colors_red = ['\033[2;31m','\033[1;31m','\033[1;91m'];
 var colors_blue = ['\033[2;34m','\033[1;34m','\033[38;5;104m'];
@@ -27,8 +29,8 @@ var clearLine = '\033[2K';
 var saveCursor = '\0337';
 var restoreCursor = '\0338';
 var normalColor = '\033[0m';
-var ui = require ('cliui');
-
+const boldText = '\033[1m';
+const italicText = '\033[3m';
 
 function getDateDiff(date /*: Date */) {
   var seconds = Math.floor((new Date() - date) / 1000);
@@ -347,6 +349,14 @@ function update_statement(current, latest) {
   return markdown(`~~Update available! Run 'aka update' to update.~~ \n!!${current}!! -> ^^${latest}^^`)
 }
 
+function bold(s) {
+  return boldText + s + normalColor;
+}
+
+function italic(s) {
+  return italicText + s + normalColor;
+}
+
 module.exports = {
   question:question,
   hidden:hidden,
@@ -369,4 +379,6 @@ module.exports = {
   friendly_date:getDateDiff,
   format_objects:format_objects,
   update_statement:update_statement,
+  bold,
+  italic,
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -90,6 +90,18 @@
         "string-width": "^1.0.1",
         "strip-ansi": "^3.0.1",
         "wrap-ansi": "^2.0.0"
+      },
+      "dependencies": {
+        "string-width": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+          "requires": {
+            "code-point-at": "^1.0.0",
+            "is-fullwidth-code-point": "^1.0.0",
+            "strip-ansi": "^3.0.0"
+          }
+        }
       }
     },
     "code-point-at": {
@@ -398,13 +410,38 @@
       "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
     },
     "string-width": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-      "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.1.0.tgz",
+      "integrity": "sha512-NrX+1dVVh+6Y9dnQ19pR0pP4FiEIlUvdTGn8pw6CKTNq5sgib2nIhmUNT5TAmhWmvKr3WcxBcP3E8nWezuipuQ==",
       "requires": {
-        "code-point-at": "^1.0.0",
-        "is-fullwidth-code-point": "^1.0.0",
-        "strip-ansi": "^3.0.0"
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^5.2.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg=="
+        },
+        "emoji-regex": {
+          "version": "8.0.0",
+          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+          "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
+        },
+        "is-fullwidth-code-point": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+          "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="
+        },
+        "strip-ansi": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+          "requires": {
+            "ansi-regex": "^4.1.0"
+          }
+        }
       }
     },
     "strip-ansi": {
@@ -453,6 +490,18 @@
       "requires": {
         "string-width": "^1.0.1",
         "strip-ansi": "^3.0.1"
+      },
+      "dependencies": {
+        "string-width": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+          "requires": {
+            "code-point-at": "^1.0.0",
+            "is-fullwidth-code-point": "^1.0.0",
+            "strip-ansi": "^3.0.0"
+          }
+        }
       }
     },
     "y18n": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "akkeris",
-  "version": "2.9.1",
+  "version": "2.9.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -115,18 +115,6 @@
       "resolved": "https://registry.npmjs.org/colors/-/colors-1.3.3.tgz",
       "integrity": "sha512-mmGt/1pZqYRjMxB1axhTo16/snVZ5krrKkcmMeVKxzECMMXoCgnvTPp10QgHfcbQZw8Dq2jMNG6je4JlWU0gWg=="
     },
-    "cross-spawn": {
-      "version": "6.0.5",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
-      "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
-      "requires": {
-        "nice-try": "^1.0.4",
-        "path-key": "^2.0.1",
-        "semver": "^5.5.0",
-        "shebang-command": "^1.2.0",
-        "which": "^1.2.9"
-      }
-    },
     "crypto-js": {
       "version": "3.1.9-1",
       "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-3.1.9-1.tgz",
@@ -142,32 +130,10 @@
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
       "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA=="
     },
-    "end-of-stream": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
-      "integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
-      "requires": {
-        "once": "^1.4.0"
-      }
-    },
     "escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
       "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
-    },
-    "execa": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/execa/-/execa-1.0.0.tgz",
-      "integrity": "sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==",
-      "requires": {
-        "cross-spawn": "^6.0.0",
-        "get-stream": "^4.0.0",
-        "is-stream": "^1.1.0",
-        "npm-run-path": "^2.0.0",
-        "p-finally": "^1.0.0",
-        "signal-exit": "^3.0.0",
-        "strip-eof": "^1.0.0"
-      }
     },
     "external-editor": {
       "version": "3.0.3",
@@ -204,14 +170,6 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
       "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="
-    },
-    "get-stream": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
-      "integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
-      "requires": {
-        "pump": "^3.0.0"
-      }
     },
     "has-flag": {
       "version": "3.0.0",
@@ -303,11 +261,6 @@
         "run-async": "^2.3.0"
       }
     },
-    "invert-kv": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-2.0.0.tgz",
-      "integrity": "sha512-wPVv/y/QQ/Uiirj/vh3oP+1Ww+AWehmi1g5fFWGPF6IpCBCDVrhgHRMvrLfdYcwDh3QJbGXDW4JAuzxElLSqKA=="
-    },
     "is-fullwidth-code-point": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
@@ -320,24 +273,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz",
       "integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o="
-    },
-    "is-stream": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
-    },
-    "isexe": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
-    },
-    "lcid": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/lcid/-/lcid-2.0.0.tgz",
-      "integrity": "sha512-avPEb8P8EGnwXKClwsNUgryVjllcRqtMYa49NTsbQagYuT1DcXnl1915oxWjoyGrXR6zH/Y0Zc96xWsPcoDKeA==",
-      "requires": {
-        "invert-kv": "^2.0.0"
-      }
     },
     "locate-path": {
       "version": "3.0.0",
@@ -352,31 +287,6 @@
       "version": "4.17.14",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.14.tgz",
       "integrity": "sha512-mmKYbW3GLuJeX+iGP+Y7Gp1AiGHGbXHCOh/jZmrawMmsE7MS4znI3RL2FsjbqOyMayHInjOeykW7PEajUk1/xw=="
-    },
-    "map-age-cleaner": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/map-age-cleaner/-/map-age-cleaner-0.1.3.tgz",
-      "integrity": "sha512-bJzx6nMoP6PDLPBFmg7+xRKeFZvFboMrGlxmNj9ClvX53KrmvM5bXFXEWjbz4cz1AFn+jWJ9z/DJSz7hrs0w3w==",
-      "requires": {
-        "p-defer": "^1.0.0"
-      }
-    },
-    "mem": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/mem/-/mem-4.3.0.tgz",
-      "integrity": "sha512-qX2bG48pTqYRVmDB37rn/6PT7LcR8T7oAX3bf99u1Tt1nzxYfxkgqDwUwolPlXweM0XzBOBFzSx4kfp7KP1s/w==",
-      "requires": {
-        "map-age-cleaner": "^0.1.1",
-        "mimic-fn": "^2.0.0",
-        "p-is-promise": "^2.0.0"
-      },
-      "dependencies": {
-        "mimic-fn": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
-          "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg=="
-        }
-      }
     },
     "mimic-fn": {
       "version": "1.2.0",
@@ -393,31 +303,10 @@
       "resolved": "https://registry.npmjs.org/netrc/-/netrc-0.1.4.tgz",
       "integrity": "sha1-a+lPysqNd63gqWcNxGCRTJRHJEQ="
     },
-    "nice-try": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
-      "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ=="
-    },
-    "npm-run-path": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
-      "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
-      "requires": {
-        "path-key": "^2.0.0"
-      }
-    },
     "number-is-nan": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
       "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
-    },
-    "once": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-      "requires": {
-        "wrappy": "1"
-      }
     },
     "onetime": {
       "version": "2.0.1",
@@ -427,40 +316,15 @@
         "mimic-fn": "^1.0.0"
       }
     },
-    "os-locale": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-3.1.0.tgz",
-      "integrity": "sha512-Z8l3R4wYWM40/52Z+S265okfFj8Kt2cC2MKY+xNi3kFs+XGI7WXu/I309QQQYbRW4ijiZ+yxs9pqEhJh0DqW3Q==",
-      "requires": {
-        "execa": "^1.0.0",
-        "lcid": "^2.0.0",
-        "mem": "^4.0.0"
-      }
-    },
     "os-tmpdir": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
       "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
     },
-    "p-defer": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/p-defer/-/p-defer-1.0.0.tgz",
-      "integrity": "sha1-n26xgvbJqozXQwBKfU+WsZaw+ww="
-    },
-    "p-finally": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
-      "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4="
-    },
-    "p-is-promise": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/p-is-promise/-/p-is-promise-2.1.0.tgz",
-      "integrity": "sha512-Y3W0wlRPK8ZMRbNq97l4M5otioeA5lm1z7bkNkxCka8HSPjR0xRWmpCmc9utiaLP9Jb1eD8BgeIxTW4AIF45Pg=="
-    },
     "p-limit": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.0.tgz",
-      "integrity": "sha512-pZbTJpoUsCzV48Mc9Nh51VbwO0X9cuPFE8gYwx9BTCt9SF8/b7Zljd2fVgOxhIF/HDTKgpVzs+GPhyKfjLLFRQ==",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.1.tgz",
+      "integrity": "sha512-85Tk+90UCVWvbDavCLKPOLC9vvY8OwEX/RtKF+/1OADJMVlFfEHOiMTPVyxg7mk/dKa+ipdHm0OUkTvCpMTuwg==",
       "requires": {
         "p-try": "^2.0.0"
       }
@@ -482,20 +346,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
       "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU="
-    },
-    "path-key": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
-      "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A="
-    },
-    "pump": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
-      "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
-      "requires": {
-        "end-of-stream": "^1.1.0",
-        "once": "^1.3.1"
-      }
     },
     "require-directory": {
       "version": "2.1.1",
@@ -537,28 +387,10 @@
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
-    "semver": {
-      "version": "5.7.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
-      "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA=="
-    },
     "set-blocking": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
       "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
-    },
-    "shebang-command": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
-      "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
-      "requires": {
-        "shebang-regex": "^1.0.0"
-      }
-    },
-    "shebang-regex": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
-      "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM="
     },
     "signal-exit": {
       "version": "3.0.2",
@@ -582,11 +414,6 @@
       "requires": {
         "ansi-regex": "^2.0.0"
       }
-    },
-    "strip-eof": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
-      "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8="
     },
     "supports-color": {
       "version": "5.5.0",
@@ -614,14 +441,6 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.3.tgz",
       "integrity": "sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ=="
     },
-    "which": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
-      "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
-      "requires": {
-        "isexe": "^2.0.0"
-      }
-    },
     "which-module": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
@@ -636,32 +455,27 @@
         "strip-ansi": "^3.0.1"
       }
     },
-    "wrappy": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
-    },
     "y18n": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
       "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w=="
     },
     "yargs": {
-      "version": "13.2.4",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-13.2.4.tgz",
-      "integrity": "sha512-HG/DWAJa1PAnHT9JAhNa8AbAv3FPaiLzioSjCcmuXXhP8MlpHO5vwls4g4j6n30Z74GVQj8Xa62dWVx1QCGklg==",
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-14.0.0.tgz",
+      "integrity": "sha512-ssa5JuRjMeZEUjg7bEL99AwpitxU/zWGAGpdj0di41pOEmJti8NR6kyUIJBkR78DTYNPZOU08luUo0GTHuB+ow==",
       "requires": {
         "cliui": "^5.0.0",
+        "decamelize": "^1.2.0",
         "find-up": "^3.0.0",
         "get-caller-file": "^2.0.1",
-        "os-locale": "^3.1.0",
         "require-directory": "^2.1.1",
         "require-main-filename": "^2.0.0",
         "set-blocking": "^2.0.0",
         "string-width": "^3.0.0",
         "which-module": "^2.0.0",
         "y18n": "^4.0.0",
-        "yargs-parser": "^13.1.0"
+        "yargs-parser": "^13.1.1"
       },
       "dependencies": {
         "ansi-regex": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "akkeris",
-  "version": "2.9.5",
+  "version": "2.9.6",
   "description": "Akkeris CLI",
   "main": "aka.js",
   "scripts": {
@@ -24,6 +24,6 @@
     "inquirer": "^6.2.2",
     "inquirer-autocomplete-prompt": "^1.0.1",
     "netrc": "^0.1.4",
-    "yargs": "^13.2.4"
+    "yargs": "^14.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "inquirer": "^6.2.2",
     "inquirer-autocomplete-prompt": "^1.0.1",
     "netrc": "^0.1.4",
+    "string-width": "^4.1.0",
     "yargs": "^14.0.0"
   }
 }

--- a/plugins/builds/index.js
+++ b/plugins/builds/index.js
@@ -400,5 +400,6 @@ module.exports = {
   },
   group:'builds',
   help:'manage builds (create, list, stop, output)',
-  primary:true
+  primary:true,
+  hidden: true,
 }

--- a/plugins/maintenance/index.js
+++ b/plugins/maintenance/index.js
@@ -51,6 +51,6 @@ module.exports = {
     // do nothing.
   },
   group:'apps',
-  help:'manage apps (create, destroy)',
+  help:'put apps in or out of maintenance mode',
   primary:true
 }


### PR DESCRIPTION
- Default command (i.e. `aka` with no command) will take you to the new `help` command.
- You can choose to use the old Akkeris help by setting `AKKERIS_HELP_OLD` to `true` or `1`, or by choosing `y` when prompted during profile setup
- You can also use the `-a` flag to show the old help (`aka help -a`)
- Commands are organized into groups (their plugin folder) and using `aka help [group]` will show all the commands in that group
- Help for individual commands can be shown by `aka help [group] [command]` or `aka [command] --help`