### PR TITLE
add meta cmds (update, version) and plugins group

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "akkeris",
-  "version": "2.9.7",
+  "version": "2.9.8",
   "description": "Akkeris CLI",
   "main": "aka.js",
   "scripts": {


### PR DESCRIPTION
Fixes the following:
- Adds the `plugins` command group to help
- Adds "meta" commands to help
  - `auth:profile`
  - `autocomplete`
  - `update`
  - `version`