### PR TITLE
fix help option alias

### DIFF
--- a/aka.js
+++ b/aka.js
@@ -766,7 +766,14 @@ module.exports.init = function init() {
   
   module.exports.args
     .usage('Usage: akkeris COMMAND [--app APP] [command-specific-options]')
-    .command(['$0 [group..]', 'help'], 'Akkeris Help', {}, help.bind(null, module.exports)).alias('a', 'all');
+    .command(['$0 [group..]', 'help'], 'Akkeris Help', {
+      all: {
+        alias: 'a',
+        boolean: true,
+        demand: false,
+        default: false,
+      },
+    }, help.bind(null, module.exports));
   
   addMetaCommands(module.exports.args);
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "akkeris",
-  "version": "2.9.9",
+  "version": "2.9.10",
   "description": "Akkeris CLI",
   "main": "aka.js",
   "scripts": {


### PR DESCRIPTION
The line of code with `.alias('a', 'all')` meant that `-a` and `-all` were aliases for each other on every command on the project - i.e. if a command had an option for `-all` AND and option for `-a` (as in `aka releases`) they would clash.

I'm pretty sure I thought that `.alias()` applied for the previous `.command()` call ... brain fart