### PR TITLE
cross platform improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@ npm -g install akkeris
 ak
 ```
 
+More information can be found in the [documentation](https://docs.akkeris.io/getting-started/prerequisites-and-installing)
+
 ## Environment Variables
 
 ```

--- a/aka.js
+++ b/aka.js
@@ -851,7 +851,7 @@ module.exports.update = function update(appkit) {
         // If `update.js` file is available, run that before the `update` function
         if (fs.statSync(path.join(appkit.config.third_party_plugins_dir, plugin, 'update.js')).isFile()) {
           try {
-            require(path.join(appkit.config.third_party_plugins_dir, plugin, 'update.js'));
+            require(path.join(appkit.config.third_party_plugins_dir, plugin, 'update.js'))(spawn);
           } catch (err) {
             console.log(appkit.terminal.markdown(` !!▸!! error updating plugin "${plugin}": ${err}`));
           }

--- a/aka.js
+++ b/aka.js
@@ -851,7 +851,16 @@ module.exports.update = function update(appkit) {
         // If `update.js` file is available, run that before the `update` function
         if (fs.statSync(path.join(appkit.config.third_party_plugins_dir, plugin, 'update.js')).isFile()) {
           try {
-            require(path.join(appkit.config.third_party_plugins_dir, plugin, 'update.js'))(spawn);
+            try {
+              require(path.join(appkit.config.third_party_plugins_dir, plugin, 'update.js'))(spawn);
+            } catch (e) {
+              // If install.js > module.exports is not a function, use old plugin install method
+              if (e instanceof TypeError) {
+                require(path.join(appkit.config.third_party_plugins_dir, plugin, 'update.js'));
+              } else {
+                throw e;
+              }
+            }
           } catch (err) {
             console.log(appkit.terminal.markdown(` !!▸!! error updating plugin "${plugin}": ${err}`));
           }

--- a/aka.js
+++ b/aka.js
@@ -3,7 +3,7 @@
 "use strict"
 
 const assert = require('assert')
-const proc = require('child_process');
+const spawn = require('cross-spawn');
 const http = require('http');
 const https = require('https');
 const fs = require('fs');
@@ -67,7 +67,7 @@ function init_plugins(m, plugins_dir, pluginName) {
 }
 
 function get_home() {
-  return process.env[(process.platform == 'win32') ? 'USERPROFILE' : 'HOME'];
+  return process.env[(process.platform === 'win32') ? 'USERPROFILE' : 'HOME'];
 }
 
 function create_dir(directory) {
@@ -291,8 +291,8 @@ function welcome() {
   console.log("to get started, you'll need your akkeris auth and apps host")
   console.log("in addition to your login and password.")
   console.log("")
-  proc.spawnSync('ak',['auth:profile'], {env:process.env, stdio:'inherit'});
-  proc.spawnSync('ak',['auth:login'], {env:process.env, stdio:'inherit'});
+  spawn.sync('ak',['auth:profile'], {env:process.env, stdio:'inherit'});
+  spawn.sync('ak',['auth:login'], {env:process.env, stdio:'inherit'});
 }
  
 let zsh_shell = process.env.SHELL && process.env.SHELL.indexOf('zsh') !== -1;
@@ -363,7 +363,7 @@ function check_for_updates() {
 // Writes output to @param update_file_path
 function spawn_update_check(update_file_path) {
   var output = fs.openSync(update_file_path, 'w');
-  proc.spawn('npm outdated akkeris --global --json', {
+  spawn('npm outdated akkeris --global --json', {
     shell: true, 
     detached: true, 
     stdio: [ 'ignore', output, 'ignore' ] 
@@ -441,17 +441,17 @@ function print_group_help(appkit, argv, group) {
   
   // Render all of the group commands
   const commands = appkit.args.getUsageInstance().getCommands().sort((a, b) => a[0] < b[0] ? -1 : 1);
-  const width = commands.reduce((acc, curr) => Math.max(stringWidth(`${argv["$0"]} ${curr[0]}`), acc), 0) + 6;
+  const width = commands.reduce((acc, curr) => Math.max(stringWidth(`${path.basename(__filename)} ${curr[0]}`), acc), 0) + 6;
   commands.forEach((command) => {
     ui.span(
-      { text: `• ${argv["$0"]} ${command[0]}`, padding: [0, 2, 0, 2], width },
+      { text: `• ${path.basename(__filename)} ${command[0]}`, padding: [0, 2, 0, 2], width },
       { text: command[1] }
     )
   });
   ui.div();
 
   // Render helper text
-  ui.div(`\n${appkit.terminal.italic('Run')} ${appkit.terminal.italic(appkit.terminal.markdown(`~~${argv["$0"]} help <group> <command>~~`))} ${appkit.terminal.italic('to view help documentation for a specific command')}`);
+  ui.div(`\n${appkit.terminal.italic('Run')} ${appkit.terminal.italic(appkit.terminal.markdown(`~~${path.basename(__filename)} help <group> <command>~~`))} ${appkit.terminal.italic('to view help documentation for a specific command')}`);
   
   print_ui(ui, errorMessage);
 }
@@ -472,10 +472,10 @@ function print_all_help(appkit, argv, errorMessage) {
 
   // Print 'meta' commands (version, update, etc)
   const metaCommands = appkit.args.getUsageInstance().getCommands().sort((a, b) => a[0] < b[0] ? -1 : 1);
-  const width = metaCommands.reduce((acc, curr) => Math.max(stringWidth(`${argv["$0"]} ${curr[0]}`), acc), 0) + 6;
+  const width = metaCommands.reduce((acc, curr) => Math.max(stringWidth(`${path.basename(__filename)} ${curr[0]}`), acc), 0) + 6;
   metaCommands.forEach((command) => {
     ui.div(
-      { text: `• ${argv["$0"]} ${command[0]}`, width },
+      { text: `• ${path.basename(__filename)} ${command[0]}`, width },
       { text: command[1] }
     )
   });
@@ -487,7 +487,7 @@ function print_all_help(appkit, argv, errorMessage) {
   });
   
   // Render helper text
-  ui.div(`\n${appkit.terminal.italic('Run')} ${appkit.terminal.italic(appkit.terminal.markdown(`~~${argv["$0"]} help <group>~~`))} ${appkit.terminal.italic('to view help documentation for a specific command group')}`);
+  ui.div(`\n${appkit.terminal.italic('Run')} ${appkit.terminal.italic(appkit.terminal.markdown(`~~${path.basename(__filename)} help <group>~~`))} ${appkit.terminal.italic('to view help documentation for a specific command group')}`);
   
   print_ui(ui, errorMessage);
 }
@@ -585,8 +585,8 @@ function find_app_middleware(appkit, argv, yargs) {
       argv.a = argv.app = process.env.AKKERIS_APP
       console.log(appkit.terminal.markdown(`###===### Using **⬢ ${argv.a}** from environment variable ##$AKKERIS_APP##`));
     } else if(!argv.a && !argv.app && !process.env.AKKERIS_APP) {
-      let branch_name = proc.spawnSync('git',['rev-parse','--abbrev-ref','HEAD'], {env:process.env}).stdout.toString('utf8').trim();
-      let apps = proc.spawnSync('git',['config','--get-regexp','branch.*.akkeris'], {env:process.env}).stdout.toString('utf8').trim();
+      let branch_name = spawn.sync('git',['rev-parse','--abbrev-ref','HEAD'], {env:process.env}).stdout.toString('utf8').trim();
+      let apps = spawn.sync('git',['config','--get-regexp','branch.*.akkeris'], {env:process.env}).stdout.toString('utf8').trim();
       if(branch_name === '' || !branch_name) {
         force_select_app();
         return
@@ -847,7 +847,7 @@ module.exports.update = function update(appkit) {
     try {
       if(fs.statSync(path.join(appkit.config.third_party_plugins_dir, plugin, '.git')).isDirectory()) {
         console.log(appkit.terminal.markdown(`###===### updating ${plugin} plugin`));
-        proc.spawnSync('git',['pull', '--quiet'], {cwd:path.join(appkit.config.third_party_plugins_dir, plugin), env:process.env, stdio:'inherit'});
+        spawn.sync('git',['pull', '--quiet'], {cwd:path.join(appkit.config.third_party_plugins_dir, plugin), env:process.env, stdio:'inherit'});
         // If `update.js` file is available, run that before the `update` function
         if (fs.statSync(path.join(appkit.config.third_party_plugins_dir, plugin, 'update.js')).isFile()) {
           try {
@@ -874,7 +874,7 @@ module.exports.update = function update(appkit) {
     }
   }));
   console.log(appkit.terminal.markdown(`###===### updating akkeris`));
-  proc.spawnSync('npm',['update', '-g', 'akkeris'], {cwd:__dirname, env:process.env, stdio:'inherit'});
+  spawn.sync('npm',['update', '-g', 'akkeris'], {cwd:__dirname, env:process.env, stdio:'inherit'});
   
   // Clear 'update available' file
   let update_file = path.join(get_home(), '.akkeris', AKA_UPDATE_FILENAME).toString('utf8')

--- a/lib/plugins.js
+++ b/lib/plugins.js
@@ -1,7 +1,7 @@
 "use strict"
 
 const assert = require('assert');
-const proc = require('child_process');
+const spawn = require('cross-spawn');
 const http = require('http');
 const https = require('https');
 const fs = require('fs');
@@ -17,6 +17,18 @@ function format_plugins(plugin) {
 }
 
 module.exports = {};
+
+// you'd better do some checks before calling this function
+function rmdir(dir) {
+  // node ^12.10 can recursively delete natively
+  if (process.versions.node > "12.10" ) {
+    fs.rmdirSync(dir, { recursive: true } )
+  } else if (process.platform === "win32") {
+    spawn.sync('rmdir', [ '/s', '/q', dir ], { cwd: process.cwd(), env: process.env, stdio: 'inherit' });
+  } else {
+    spawn.sync('rm', [ '-rf', dir ], { cwd: process.cwd(), env: process.env, stdio: 'inherit' });
+  }
+}
 
 function plugins_list(appkit, args) {
   appkit.api.get('/plugins', 
@@ -97,11 +109,11 @@ function plugins_install(appkit, args) {
     try {
       tmp_dir = path.join(appkit.config.third_party_plugins_dir, (".tmp" + Math.floor(Math.random() * 1000)));
       fs.mkdirSync(tmp_dir);
-      proc.spawnSync('git', ['clone', args.GITHUB_REPO, tmp_dir], {cwd:process.cwd(), env:process.env, stdio:'ignore'});
+      spawn.sync('git', ['clone', args.GITHUB_REPO, tmp_dir], {cwd:process.cwd(), env:process.env, stdio:'ignore'});
       if(fs.statSync(path.join(tmp_dir, 'index.js')).isFile()) {
         try {
           if(fs.statSync(path.join(tmp_dir, 'install.js')).isFile()) {
-            require(path.join(tmp_dir, 'install.js'))
+            require(path.join(tmp_dir, 'install.js'))(spawn)
           }
         } catch (e) {
           // do nothing.
@@ -126,7 +138,7 @@ function plugins_install(appkit, args) {
       if(tmp_dir) {
         assert.ok(tmp_dir !== '/', 'Something really bad happened (tmp_dir === /).');
         assert.ok(tmp_dir.indexOf(appkit.config.third_party_plugins_dir) > -1, 'Something bad happened tmp_dir was not in plugins path.');
-        proc.spawnSync('rm',['-rf',tmp_dir], {cwd:process.cwd(), env:process.env, stdio:'inherit'});
+        rmdir(tmp_dir);
       }
     }
   };
@@ -137,7 +149,6 @@ function plugins_install(appkit, args) {
       if(err) {
         return appkit.terminal.error('The specified plugin could not be found.');
       }
-
       args.GITHUB_REPO = plugin.repo;
       pull_and_install();
     });
@@ -145,13 +156,13 @@ function plugins_install(appkit, args) {
 }
 
 function plugins_uninstall(appkit, args) {
-  assert.ok(appkit.plugins[args.PLUGIN], 'The specified plugin does not exist, use "appkit version" to get a list of installed plugins.');
   try {
+    assert.ok(appkit.plugins[args.PLUGIN], 'The specified plugin does not exist, use "aka version" to get a list of installed plugins.');
     if(fs.statSync(path.join(appkit.config.third_party_plugins_dir, args.PLUGIN, '.git')).isDirectory()) {
       let tmp_dir = path.join(appkit.config.third_party_plugins_dir, args.PLUGIN);
       assert.ok(tmp_dir !== '/', 'Something really bad happened (tmp_dir === /).');
       assert.ok(tmp_dir.indexOf(appkit.config.third_party_plugins_dir) > -1, 'Something bad happened tmp_dir was not in plugins path.');
-      proc.spawnSync('rm',['-rf',tmp_dir], {cwd:process.cwd(), env:process.env, stdio:'inherit'});
+      rmdir(tmp_dir);
     } else {
       throw new Error("No such plug-in found.");
     }
@@ -159,7 +170,7 @@ function plugins_uninstall(appkit, args) {
     if(e.message.indexOf("ENOENT") > -1) {
       appkit.terminal.error(`You cannot uninstall the core plugin ${args.PLUGIN}, sorry.`);
     } else {
-      appkit.terminal.error(`Unable to install plugin ${args.PLUGIN}: ${e.message}`);
+      appkit.terminal.error(`Unable to uninstall plugin ${args.PLUGIN}: ${e.message}`);
     }
   }
 }
@@ -175,7 +186,7 @@ module.exports.init = function(args, appkit) {
       'alias':'r',
       'type':'string',
       'demand':true,
-      'description':'The repo for the plugin (e.g. https://github.com/foo/bar) '
+      'description':'The repo for the plugin (e.g. https://github.com/foo/bar)'
     },
     'owner':{
       'alias':'o',
@@ -200,7 +211,7 @@ module.exports.init = function(args, appkit) {
     'repo':{
       'alias':'r',
       'type':'string',
-      'description':'The repo for the plugin (e.g. https://github.com/foo/bar) '
+      'description':'The repo for the plugin (e.g. https://github.com/foo/bar)'
     },
     'owner':{
       'alias':'o',

--- a/lib/plugins.js
+++ b/lib/plugins.js
@@ -113,7 +113,16 @@ function plugins_install(appkit, args) {
       if(fs.statSync(path.join(tmp_dir, 'index.js')).isFile()) {
         try {
           if(fs.statSync(path.join(tmp_dir, 'install.js')).isFile()) {
-            require(path.join(tmp_dir, 'install.js'))(spawn)
+            try {
+              require(path.join(tmp_dir, 'install.js'))(spawn);
+            } catch (err) {
+              // If install.js > module.exports is not a function, use old plugins install method
+              if (err instanceof TypeError) {
+                require(path.join(tmp_dir, 'install.js'));
+              } else {
+                throw err;
+              }
+            }
           }
         } catch (e) {
           // do nothing.

--- a/lib/plugins.js
+++ b/lib/plugins.js
@@ -1,13 +1,15 @@
 "use strict"
 
 const assert = require('assert');
-const spawn = require('cross-spawn');
+const proc = require('child_process');
 const http = require('http');
 const https = require('https');
 const fs = require('fs');
 const path = require('path');
 const url = require('url');
 const zlib = require('zlib');
+
+const isWindows = process.platform === 'win32';
 
 function format_plugins(plugin) {
   return `**:: ${plugin.name}**
@@ -23,10 +25,10 @@ function rmdir(dir) {
   // node ^12.10 can recursively delete natively
   if (process.versions.node > "12.10" ) {
     fs.rmdirSync(dir, { recursive: true } )
-  } else if (process.platform === "win32") {
-    spawn.sync('rmdir', [ '/s', '/q', dir ], { cwd: process.cwd(), env: process.env, stdio: 'inherit' });
+  } else if (isWindows) {
+    proc.spawnSync('rmdir', [ '/s', '/q', dir ], { cwd: process.cwd(), env: process.env, stdio: 'inherit', shell: true });
   } else {
-    spawn.sync('rm', [ '-rf', dir ], { cwd: process.cwd(), env: process.env, stdio: 'inherit' });
+    proc.spawnSync('rm', [ '-rf', dir ], { cwd: process.cwd(), env: process.env, stdio: 'inherit' });
   }
 }
 
@@ -109,20 +111,11 @@ function plugins_install(appkit, args) {
     try {
       tmp_dir = path.join(appkit.config.third_party_plugins_dir, (".tmp" + Math.floor(Math.random() * 1000)));
       fs.mkdirSync(tmp_dir);
-      spawn.sync('git', ['clone', args.GITHUB_REPO, tmp_dir], {cwd:process.cwd(), env:process.env, stdio:'ignore'});
+      proc.spawnSync('git', ['clone', args.GITHUB_REPO, tmp_dir], {cwd:process.cwd(), env:process.env, stdio:'ignore', shell: isWindows || undefined});
       if(fs.statSync(path.join(tmp_dir, 'index.js')).isFile()) {
         try {
           if(fs.statSync(path.join(tmp_dir, 'install.js')).isFile()) {
-            try {
-              require(path.join(tmp_dir, 'install.js'))(spawn);
-            } catch (err) {
-              // If install.js > module.exports is not a function, use old plugins install method
-              if (err instanceof TypeError) {
-                require(path.join(tmp_dir, 'install.js'));
-              } else {
-                throw err;
-              }
-            }
+            require(path.join(tmp_dir, 'install.js'))
           }
         } catch (e) {
           // do nothing.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "akkeris",
-  "version": "2.9.6",
+  "version": "2.9.11",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -121,6 +121,16 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/colors/-/colors-1.4.0.tgz",
       "integrity": "sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA=="
+    },
+    "cross-spawn": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.1.tgz",
+      "integrity": "sha512-u7v4o84SwFpD32Z8IIcPZ6z1/ie24O6RU3RbtL5Y316l3KuHVPx9ItBgWQ6VlfAFnRnTtMUrsQ9MUUTuEZjogg==",
+      "requires": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      }
     },
     "crypto-js": {
       "version": "3.1.9-1",
@@ -278,6 +288,11 @@
       "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz",
       "integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o="
     },
+    "isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
+    },
     "locate-path": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
@@ -346,6 +361,11 @@
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
       "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU="
     },
+    "path-key": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.0.tgz",
+      "integrity": "sha512-8cChqz0RP6SHJkMt48FW0A7+qUOn+OsnOsVtzI59tZ8m+5bCSk7hzwET0pulwOM2YMn9J1efb07KB9l9f30SGg=="
+    },
     "require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
@@ -390,6 +410,19 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
       "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
+    },
+    "shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "requires": {
+        "shebang-regex": "^3.0.0"
+      }
+    },
+    "shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="
     },
     "signal-exit": {
       "version": "3.0.2",
@@ -464,6 +497,14 @@
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.10.0.tgz",
       "integrity": "sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ=="
+    },
+    "which": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.1.tgz",
+      "integrity": "sha512-N7GBZOTswtB9lkQBZA4+zAXrjEIWAUOB93AvzUiudRzRxhUdLURQ7D/gAIMY1gatT/LTbmbcv8SiYazy3eYB7w==",
+      "requires": {
+        "isexe": "^2.0.0"
+      }
     },
     "which-module": {
       "version": "2.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -122,16 +122,6 @@
       "resolved": "https://registry.npmjs.org/colors/-/colors-1.4.0.tgz",
       "integrity": "sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA=="
     },
-    "cross-spawn": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.1.tgz",
-      "integrity": "sha512-u7v4o84SwFpD32Z8IIcPZ6z1/ie24O6RU3RbtL5Y316l3KuHVPx9ItBgWQ6VlfAFnRnTtMUrsQ9MUUTuEZjogg==",
-      "requires": {
-        "path-key": "^3.1.0",
-        "shebang-command": "^2.0.0",
-        "which": "^2.0.1"
-      }
-    },
     "crypto-js": {
       "version": "3.1.9-1",
       "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-3.1.9-1.tgz",
@@ -288,11 +278,6 @@
       "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz",
       "integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o="
     },
-    "isexe": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
-    },
     "locate-path": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
@@ -361,11 +346,6 @@
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
       "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU="
     },
-    "path-key": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.0.tgz",
-      "integrity": "sha512-8cChqz0RP6SHJkMt48FW0A7+qUOn+OsnOsVtzI59tZ8m+5bCSk7hzwET0pulwOM2YMn9J1efb07KB9l9f30SGg=="
-    },
     "require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
@@ -410,19 +390,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
       "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
-    },
-    "shebang-command": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
-      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-      "requires": {
-        "shebang-regex": "^3.0.0"
-      }
-    },
-    "shebang-regex": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
-      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="
     },
     "signal-exit": {
       "version": "3.0.2",
@@ -497,14 +464,6 @@
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.10.0.tgz",
       "integrity": "sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ=="
-    },
-    "which": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/which/-/which-2.0.1.tgz",
-      "integrity": "sha512-N7GBZOTswtB9lkQBZA4+zAXrjEIWAUOB93AvzUiudRzRxhUdLURQ7D/gAIMY1gatT/LTbmbcv8SiYazy3eYB7w==",
-      "requires": {
-        "isexe": "^2.0.0"
-      }
     },
     "which-module": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,6 @@
     "cli-table": "^0.3.1",
     "cliui": "^5.0.0",
     "colors": "^1.3.3",
-    "cross-spawn": "^7.0.1",
     "crypto-js": "^3.1.9-1",
     "fuzzy": "^0.1.3",
     "inquirer": "^6.2.2",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "cli-table": "^0.3.1",
     "cliui": "^5.0.0",
     "colors": "^1.3.3",
+    "cross-spawn": "^7.0.1",
     "crypto-js": "^3.1.9-1",
     "fuzzy": "^0.1.3",
     "inquirer": "^6.2.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "akkeris",
-  "version": "2.9.11",
+  "version": "2.9.12",
   "description": "Akkeris CLI",
   "main": "aka.js",
   "scripts": {

--- a/plugins/apps/index.js
+++ b/plugins/apps/index.js
@@ -1,9 +1,11 @@
 "use strict"
 
 const assert = require('assert');
-const spawn = require('cross-spawn');
+const proc = require('child_process');
 const fs = require('fs');
 const rand = require('./random.js');
+
+const isWindows = process.platform === 'win32';
 
 function format_app(app) {
   let upname = app.simple_name.toUpperCase();
@@ -253,7 +255,7 @@ function open(appkit, args) {
     if(err) {
       return appkit.terminal.error(err)
     }
-    spawn('open', [data.web_url], {});
+    proc.spawnSync(isWindows ? 'start' : 'open', [data.web_url], {shell: isWindows || undefined});
   });
 }
 

--- a/plugins/apps/index.js
+++ b/plugins/apps/index.js
@@ -1,7 +1,7 @@
 "use strict"
 
 const assert = require('assert');
-const proc = require('child_process');
+const spawn = require('cross-spawn');
 const fs = require('fs');
 const rand = require('./random.js');
 
@@ -253,7 +253,7 @@ function open(appkit, args) {
     if(err) {
       return appkit.terminal.error(err)
     }
-    proc.spawn('open', [data.web_url], {});
+    spawn('open', [data.web_url], {});
   });
 }
 

--- a/plugins/audits/index.js
+++ b/plugins/audits/index.js
@@ -1,8 +1,6 @@
 "use strict"
 
 const assert = require ('assert')
-const proc = require('child_process');
-const fs = require('fs');
 const SHA256 = require('crypto-js/sha256');
 
 function get_repo(repo) {

--- a/plugins/metrics/index.js
+++ b/plugins/metrics/index.js
@@ -1,7 +1,6 @@
 "use strict"
 
 const chart = require('chart');
-const child_process = require('child_process');
 
 let cpu_metrics = ['cpu_system_seconds_total', 'cpu_usage_seconds_total', 'cpu_user_seconds_total'];
 let memory_metrics = ['memory_usage_bytes', 'memory_cache', 'memory_rss', 'memory_working_set_bytes'];


### PR DESCRIPTION
- Use `cross-spawn` package for spawning child processes
- Use `path.basename(__filename)` instead of `argv["$0"]` for script name
- Improve temporary folder deletion
- Provide `cross-spawn` as a parameter to `install.js` during plugin installation
  - This lets plugins use `cross-spawn` during installation for things like `npm install`
