### PR TITLE
tweak apps:info, add 'attached from' to addons

### DIFF
--- a/lib/terminal.js
+++ b/lib/terminal.js
@@ -163,7 +163,7 @@ function fromKeyedArrayToTable(data) {
   return out;
 }
 
-function table(obj) {
+function table(obj, noOutput) {
   if(obj.length === 0) {
     console.log('No data found.');
     return;
@@ -180,6 +180,9 @@ function table(obj) {
     });
     t.push(d);
   });
+  if (noOutput) {
+    return t.toString();
+  }
   console.log(t.toString());
 }
 
@@ -264,6 +267,11 @@ function print(err, obj, sort) {
   }
 }
 
+/**
+ * Format markdown-style tags surrounding text in a string to ASCII color tags
+ * \*\*blue\*\* \~\~yellow\~\~ !!red!! ##gray## ^^green^^
+ * @param {string} strs String to format
+ */
 function markdown(strs) {
   if (process.env.AKA_NO_COLORS) {
     return strs.replace(/(\*\*\*)(.+)(\*\*\*)/g, '$2')

--- a/lib/terminal.js
+++ b/lib/terminal.js
@@ -163,7 +163,7 @@ function fromKeyedArrayToTable(data) {
   return out;
 }
 
-function table(obj, noOutput) {
+function table(obj) {
   if(obj.length === 0) {
     console.log('No data found.');
     return;
@@ -180,9 +180,6 @@ function table(obj, noOutput) {
     });
     t.push(d);
   });
-  if (noOutput) {
-    return t.toString();
-  }
   console.log(t.toString());
 }
 


### PR DESCRIPTION
Remove addon display from `apps:info` as it was getting cluttered - added message to use `addons -a appname` instead

Added `attached from` to the addon info page for apps

Also added a helper jsdoc so I could remember which characters create which colors on `appkit.terminal.markdown`