### PR TITLE
Fix for apps:info crash if app is not in a pipeline

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "akkeris",
-  "version": "2.9.17",
+  "version": "2.9.18",
   "description": "Akkeris CLI",
   "main": "aka.js",
   "scripts": {

--- a/plugins/apps/index.js
+++ b/plugins/apps/index.js
@@ -168,7 +168,15 @@ async function info(appkit, args) {
   assert.ok(args.app && args.app !== '', 'An application name was not provided.');
   try {
       const app = await appkit.api.get('/apps/' + args.app);
-      const pipeline = await appkit.api.get('/apps/' + args.app + '/pipeline-couplings');
+      
+      let pipeline;
+      try {
+        pipeline = await appkit.api.get('/apps/' + args.app + '/pipeline-couplings');
+      } catch (err) {
+        if (err.code !== 404) {
+          throw err
+        }
+      }
 
       const ui = require('cliui')();
 


### PR DESCRIPTION
ignore 404 response to `/apps/app-space/pipeline-couplings`

... d'oh