### PR TITLE
aka hooks:fetch - Dynamically get hook events from controller

### DIFF
--- a/lib/terminal.js
+++ b/lib/terminal.js
@@ -1,7 +1,7 @@
 const util = require('util');
 const assert = require('assert');
 var ui = require ('cliui');
-var cli_table = require('cli-table');
+var cli_table = require('cli-table3');
 
 // colors array: [dark, med, light]
 var colors_red = ['\033[2;31m','\033[1;31m','\033[1;91m'];
@@ -163,13 +163,13 @@ function fromKeyedArrayToTable(data) {
   return out;
 }
 
-function table(obj) {
+function table(obj, options) {
   if(obj.length === 0) {
     console.log('No data found.');
     return;
   }
   var keys = Object.keys(obj[0]);
-  var t = new cli_table({head:keys,style:{head:['bold','blue']}});
+  var t = new cli_table({head:keys,style:{head:['bold','blue']}, ...options});
   obj.forEach(function(o) {
     var d = [];
     keys.forEach(function(k) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "akkeris",
-  "version": "2.9.13",
+  "version": "3.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -62,18 +62,37 @@
         "restore-cursor": "^2.0.0"
       }
     },
-    "cli-table": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/cli-table/-/cli-table-0.3.1.tgz",
-      "integrity": "sha1-9TsFJmqLGguTSz0IIebi3FkUriM=",
+    "cli-table3": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/cli-table3/-/cli-table3-0.5.1.tgz",
+      "integrity": "sha512-7Qg2Jrep1S/+Q3EceiZtQcDPWxhAvBw+ERf1162v4sikJrvojMHFqXt8QIVha8UlH9rgU0BeWPytZ9/TzYqlUw==",
       "requires": {
-        "colors": "1.0.3"
+        "colors": "^1.1.2",
+        "object-assign": "^4.1.0",
+        "string-width": "^2.1.1"
       },
       "dependencies": {
-        "colors": {
-          "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
-          "integrity": "sha1-BDP0TYCWgP3rYO0mDxsMJi6CpAs="
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
+        },
+        "string-width": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+          "requires": {
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^4.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "requires": {
+            "ansi-regex": "^3.0.0"
+          }
         }
       }
     },
@@ -306,6 +325,11 @@
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/netrc/-/netrc-0.1.4.tgz",
       "integrity": "sha1-a+lPysqNd63gqWcNxGCRTJRHJEQ="
+    },
+    "object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
     },
     "onetime": {
       "version": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "akkeris",
-  "version": "3.0.1",
+  "version": "3.1.0",
   "description": "Akkeris CLI",
   "main": "aka.js",
   "scripts": {
@@ -16,7 +16,7 @@
   "license": "ISC",
   "dependencies": {
     "chart": "github:jstrace/chart",
-    "cli-table": "^0.3.1",
+    "cli-table3": "^0.5.1",
     "cliui": "^5.0.0",
     "colors": "^1.3.3",
     "crypto-js": "^3.1.9-1",

--- a/plugins/hooks/index.js
+++ b/plugins/hooks/index.js
@@ -86,6 +86,15 @@ function result(appkit, args) {
     })
 }
 
+async function fetch_hooks(appkit, args) {
+  try {
+    const availableHooks = (await appkit.api.get('/docs/hooks')).map(x => ({event: x.type, description: x.description}));
+    appkit.terminal.table(availableHooks, { colWidths: [20, 100], wordWrap: true})
+  } catch (err) {
+    appkit.terminal.print(err);
+  }
+}
+
 module.exports = {
   
   init:function(appkit) {
@@ -116,7 +125,7 @@ module.exports = {
       array:true,
       demand:true,
       alias:'e',
-      description:'A space separated list of one or more events [build release formation_change logdrain_change addon_change config_change destory preview released crashed preview-released]'
+      description:'A space separated list of one or more events (for a list of available events, use aka hooks:fetch)'
     };
     hooks_create_options.secret = {
       string:true,
@@ -137,6 +146,7 @@ module.exports = {
       .command('hooks:destroy ID', 'Remove the specified webhook', hooks_options, delete_hooks.bind(null, appkit))
       .command('hooks:create URL', 'Configure a new webhook', hooks_create_options, create_hooks.bind(null, appkit))
       .command('hooks:deliveries ID', 'Get information on the delivery of a webhook', hook_results_options, result.bind(null, appkit))
+      .command('hooks:fetch', 'Get a list of available Akkeris hooks', {}, fetch_hooks.bind(null, appkit))
       // Aliases
       .command('hooks:remove ID', false, hooks_options, delete_hooks.bind(null, appkit))
       .command('hooks:delete ID', false, hooks_options, delete_hooks.bind(null, appkit))


### PR DESCRIPTION
- Change dependency on the deprecated `cli-table` to `cli-table3` which has more features and is actively maintained (gets regular security updates) while still being backwards-compatible with `cli-table`
- Add `aka hooks:fetch` which gets a list of available hook events & descriptions from the controller