### PR TITLE
use semver package instead of string comparison

### DIFF
--- a/lib/plugins.js
+++ b/lib/plugins.js
@@ -2,6 +2,7 @@ const assert = require('assert');
 const proc = require('child_process');
 const fs = require('fs');
 const path = require('path');
+const semverGte = require('semver/functions/gte');
 
 const isWindows = process.platform === 'win32';
 
@@ -17,7 +18,7 @@ module.exports = {};
 // you'd better do some checks before calling this function
 function rmdir(dir) {
   // node ^12.10 can recursively delete natively
-  if (process.versions.node > '12.10') {
+  if (semverGte(process.versions.node, '12.10.0')) {
     fs.rmdirSync(dir, { recursive: true });
   } else if (isWindows) {
     proc.spawnSync('rmdir', ['/s', '/q', dir], {

--- a/package-lock.json
+++ b/package-lock.json
@@ -570,6 +570,12 @@
             "is-promise": "^2.1.0"
           }
         },
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+          "dev": true
+        },
         "supports-color": {
           "version": "7.1.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
@@ -1659,10 +1665,9 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
     "semver": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-      "dev": true
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.1.3.tgz",
+      "integrity": "sha512-ekM0zfiA9SCBlsKa2X1hxyxiI4L3B6EbVJkkdgQXnSEEaHlGdvyodMruTiulSRWMMB4NeIuYNMC9rTKTz97GxA=="
     },
     "set-blocking": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "inquirer": "^6.2.2",
     "inquirer-autocomplete-prompt": "^1.0.1",
     "netrc": "^0.1.4",
+    "semver": "^7.1.3",
     "string-width": "^4.1.0",
     "yargs": "^15.3.1"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "akkeris",
-  "version": "3.1.6",
+  "version": "3.1.7",
   "description": "Akkeris CLI",
   "main": "aka.js",
   "scripts": {


### PR DESCRIPTION
Not sure why I tried to compare the node version as a string, that was a brain fart.

Added NPM's "semver" package as a dependency, which is already required by a number of our dependencies anyway. Tested installing plugins with node 8 and it worked fine