### PR TITLE
improve plugin installation error messages

### DIFF
--- a/lib/plugins.js
+++ b/lib/plugins.js
@@ -111,9 +111,22 @@ function plugins_install(appkit, args) {
     try {
       tmp_dir = path.join(appkit.config.third_party_plugins_dir, (`.tmp${Math.floor(Math.random() * 1000)}`));
       fs.mkdirSync(tmp_dir);
-      proc.spawnSync('git', ['clone', args.GITHUB_REPO, tmp_dir], {
-        cwd: process.cwd(), env: process.env, stdio: 'ignore', shell: isWindows || undefined,
+      const output = proc.spawnSync('git', ['clone', args.GITHUB_REPO, tmp_dir], {
+        cwd: process.cwd(), env: process.env, shell: isWindows || undefined,
       });
+
+      if (output.stderr && output.stderr.toString().toLowerCase().includes('authentication failed')) {
+        throw new Error('Error accessing plugin repository - The GitHub username and password were incorrect.');
+      }
+
+      if (output.stderr && output.stderr.toString().toLowerCase().includes('enabled or enforced saml sso')) {
+        const parsedOutput = output.stderr.toString().match(/(https:\/\/github.com.*)\s/);
+        if (parsedOutput.length < 2) {
+          throw new Error('Error accessing plugin repository - SSO authentication needed.\n\nFor more information, see https://help.github.com/en/github/authenticating-to-github/authorizing-a-personal-access-token-for-use-with-saml-single-sign-on\n');
+        }
+        throw new Error(`Error accessing plugin repository - SSO authentication needed\n\nVisit ${parsedOutput[1]} and try your request again.\n\nFor more information, see https://help.github.com/en/github/authenticating-to-github/authorizing-a-personal-access-token-for-use-with-saml-single-sign-on\n`);
+      }
+
       if (fs.statSync(path.join(tmp_dir, 'index.js')).isFile()) {
         try {
           if (fs.statSync(path.join(tmp_dir, 'install.js')).isFile()) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "akkeris",
-  "version": "3.1.8",
+  "version": "3.1.9",
   "description": "Akkeris CLI",
   "main": "aka.js",
   "scripts": {


### PR DESCRIPTION
When installing plugins, capture `stderr` and look for either "authentication failed" or "enabled SAML SSO". Then, let the user know what happened (and provide the validation URL if available)