### PR TITLE
fix bug with help command, version command

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "akkeris",
-  "version": "3.1.14",
+  "version": "3.1.15",
   "description": "Akkeris CLI",
   "main": "aka.js",
   "scripts": {


### PR DESCRIPTION
- Handle getting help for specific commands a bit cleaner
- When a user runs `aka version`, it should only return installed 3rd party plugins.