### PR TITLE
Add Docker Image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+*node_modules*
+*.git
+.dockerignore
+Dockerfile
+.gitignore
+.github
+.eslintrc.json

--- a/.github/workflows/merge_docker.yml
+++ b/.github/workflows/merge_docker.yml
@@ -1,0 +1,20 @@
+name: Publish Docker Image on Merge to Master
+on:
+  push:
+    branches:
+      - master
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@master
+    - name: Get NPM Version
+      id: package-version
+      uses: martinbeentjes/npm-get-version-action@master
+    - name: Publish to Docker Registry
+      uses: elgohr/Publish-Docker-Github-Action@master
+      with:
+        name: akkeris/cli
+        username: ${{ secrets.DOCKER_USERNAME }}
+        password: ${{ secrets.DOCKER_PASSWORD }}
+        tags: "latest,${{ steps.package-version.outputs.current-version}}"

--- a/.github/workflows/release_docker.yml
+++ b/.github/workflows/release_docker.yml
@@ -1,0 +1,16 @@
+name: Publish Docker Image on Release
+on: 
+  release:
+    types: [published]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@master
+    - name: Publish to Docker Registry
+      uses: elgohr/Publish-Docker-Github-Action@master
+      with:
+        name: akkeris/cli
+        username: ${{ secrets.DOCKER_USERNAME }}
+        password: ${{ secrets.DOCKER_PASSWORD }}
+        tag_names: true

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,2 @@
 .DS_Store
 node_modules
-Dockerfile
-.dockerignore

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM node:12-alpine
+RUN apk add --no-cache git
+WORKDIR /usr/src/app
+COPY package*.json /usr/src/app/
+RUN npm ci --only=production
+COPY . /usr/src/app/
+ENTRYPOINT [ "node", "aka.js" ]

--- a/README.md
+++ b/README.md
@@ -30,3 +30,42 @@ Make sure you've added the entries to .netrc as well.
 ## Documentation
 
 [https://docs.akkeris.io/](https://docs.akkeris.io/)
+
+## Running in Docker
+
+If you don't want to have Node.js installed, or just want to run the Akkeris CLI in a Docker container, you can build a Docker image with:
+
+```bash
+docker build -t akkeris-cli .
+```
+
+Or use pre-built image from DockerHub: `akkeris/cli`
+
+### Authentication
+
+You can optionally bind your `~/.netrc` and `~/.akkeris/config.json` files to the Docker container so you don't have to go through the profile setup and login process each time you use the container. If you don't have either of those files set up yet, create them.
+
+For example, on MacOS:
+
+```bash
+touch ~/.netrc && mkdir -p ~/.akkeris && touch ~/.akkeris/config.json
+docker run --rm -it -v ~/.netrc:/root/.netrc -v ~/.akkeris/config.json:/root/.akkeris/config.json akkeris/cli [COMMAND]
+```
+
+### Plugins
+
+You can bind a plugins directory to the Docker container if you want to have plugins persist between usages of the Docker container:
+
+```bash
+docker run --rm -it -v ~/.akkeris/plugins/:/root/.akkeris/plugins/ akkeris/cli [COMMAND]
+```
+
+### Alias
+
+For easier use, you can add an alias to your bash profile:
+
+```bash
+alias aka="docker run --rm -it -v ~/.akkeris/plugins/:/root/.akkeris/plugins/ -v ~/.netrc:/root/.netrc -v ~/.akkeris/config.json:/root/.akkeris/config.json akkeris/cli"
+```
+
+Then, you can run Akkeris commands inside a Docker container like you had the Akkeris CLI installed locally: `aka version`


### PR DESCRIPTION
This should let people who are having trouble installing the CLI for whatever reason (e.g. Windows users?) use a Docker image instead. I've also added two Actions that should push new images to DockerHub on a new release tag as well as a new push to master.