### PR TITLE
Bump package version in preperation for release

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "akkeris",
-  "version": "3.1.20",
+  "version": "3.1.21",
   "description": "Akkeris CLI",
   "main": "aka.js",
   "scripts": {


### PR DESCRIPTION
Bump to 3.1.21 to prepare for releasing the beta recommendations-api commands