### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/merge_docker.yml
+++ b/.github/workflows/merge_docker.yml
@@ -12,7 +12,7 @@ jobs:
       id: package-version
       uses: martinbeentjes/npm-get-version-action@master
     - name: Publish to Docker Registry
-      uses: elgohr/Publish-Docker-Github-Action@master
+      uses: elgohr/Publish-Docker-Github-Action@v5
       with:
         name: akkeris/cli
         username: ${{ secrets.DOCKER_USERNAME }}

--- a/.github/workflows/release_docker.yml
+++ b/.github/workflows/release_docker.yml
@@ -8,7 +8,7 @@ jobs:
     steps:
     - uses: actions/checkout@master
     - name: Publish to Docker Registry
-      uses: elgohr/Publish-Docker-Github-Action@master
+      uses: elgohr/Publish-Docker-Github-Action@v5
       with:
         name: akkeris/cli
         username: ${{ secrets.DOCKER_USERNAME }}


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore