### PR TITLE
bug: add csp as a valid filter type

### DIFF
--- a/plugins/filters/index.js
+++ b/plugins/filters/index.js
@@ -285,7 +285,7 @@ module.exports = {
       },
       type: {
         alias: 't',
-        choices: ['jwt', 'cors'],
+        choices: ['jwt', 'cors', 'csp'],
         demand: true,
         description: 'The type of http filter.',
       },


### PR DESCRIPTION
We noticed we cannot create `csp` filters using the Akkeris CLI due to the input validation.